### PR TITLE
Move to 2024-05-18 nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ memmap = "0.7.0"
 term-painter = "0.3.0"
 libc = "0.2.82"
 impl-trait-for-tuples = "0.2.0"
-crndm_derive = "0.1.1"
+crndm_derive = { path="./crndm_derive"}
 num_cpus = "1.13.0"
 
 # examples
 rand = "0.8.4"
-regex = "1.5.4"
+regex = "=1.5.4"
 num = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ num_cpus = "1.13.0"
 
 # examples
 rand = "0.8.4"
-regex = "=1.5.4"
+regex = "1.5.4"
 num = "0.4.0"

--- a/crndm_derive/Cargo.toml
+++ b/crndm_derive/Cargo.toml
@@ -19,7 +19,6 @@ quote = "1.0"
 regex = "1"
 proc-macro-error = "1"
 cbindgen = "0.20.0"
-tempfile = "3.0"
 
 [dependencies.syn]
 version = "1.0"

--- a/crndm_derive/Cargo.toml
+++ b/crndm_derive/Cargo.toml
@@ -19,6 +19,7 @@ quote = "1.0"
 regex = "1"
 proc-macro-error = "1"
 cbindgen = "0.20.0"
+tempfile = "=3.0"
 
 [dependencies.syn]
 version = "1.0"

--- a/crndm_derive/Cargo.toml
+++ b/crndm_derive/Cargo.toml
@@ -19,7 +19,7 @@ quote = "1.0"
 regex = "1"
 proc-macro-error = "1"
 cbindgen = "0.20.0"
-tempfile = "=3.0"
+tempfile = "3.0"
 
 [dependencies.syn]
 version = "1.0"

--- a/crndm_derive/src/cbinding.rs
+++ b/crndm_derive/src/cbinding.rs
@@ -6,7 +6,7 @@ use syn::spanned::Spanned;
 use syn::*;
 use syn::punctuated::Punctuated;
 use std::collections::HashMap;
-use std::lazy::SyncLazy;
+use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::io::*;
 use std::fs::{File,create_dir_all,read_to_string};
@@ -36,11 +36,11 @@ pub struct Attributes {
     concurrent: bool
 }
 
-pub static mut TYPES: SyncLazy<Mutex<HashMap<TypeName, Contents>>> = SyncLazy::new(|| {
+pub static mut TYPES: LazyLock<Mutex<HashMap<TypeName, Contents>>> = LazyLock::new(|| {
     Mutex::new(HashMap::new())
 });
 
-pub static mut POOLS: SyncLazy<Mutex<HashMap<TypeName, Contents>>> = SyncLazy::new(|| {
+pub static mut POOLS: LazyLock<Mutex<HashMap<TypeName, Contents>>> = LazyLock::new(|| {
     Mutex::new(HashMap::new())
 });
 
@@ -280,7 +280,7 @@ pub fn derive_cbindgen(input: TokenStream) -> TokenStream {
         Ok(g) => g,
         Err(p) => p.into_inner()
     } };
-    let mut entry = all_types.entry(name_str.clone()).or_insert(Contents::default());
+    let entry = all_types.entry(name_str.clone()).or_insert(Contents::default());
     entry.generics = generics.iter().map(|v| v.to_string()).collect();
     let new_sizes: Vec<Ident>  = generics.iter().map(|v| format_ident!("{}_size", v.to_string())).collect();
 

--- a/crndm_derive/src/lib.rs
+++ b/crndm_derive/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(once_cell)]
-#![feature(type_name_of_val)]
+#![feature(lazy_cell)]
 #![feature(proc_macro_span)]
 
 use proc_macro2::Group;

--- a/crndm_derive/src/lib.rs
+++ b/crndm_derive/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(lazy_cell)]
 #![feature(proc_macro_span)]
 
 use proc_macro2::Group;

--- a/eval/run.sh
+++ b/eval/run.sh
@@ -63,7 +63,6 @@ do
 done
 
 source $HOME/.corundum/env
-rustup default nightly
 
 [ -f $dir_path/inputs.tar.gz ] || [ -d $dir_path/inputs ] || \
     wget https://github.com/NVSL/Corundum/raw/24130f8789b4bed6cf6526562045586e19e88592/eval/inputs.tar.gz

--- a/eval/run.sh
+++ b/eval/run.sh
@@ -63,6 +63,7 @@ do
 done
 
 source $HOME/.corundum/env
+rustup default nightly
 
 [ -f $dir_path/inputs.tar.gz ] || [ -d $dir_path/inputs ] || \
     wget https://github.com/NVSL/Corundum/raw/24130f8789b4bed6cf6526562045586e19e88592/eval/inputs.tar.gz

--- a/examples/mapcli/map/mod.rs
+++ b/examples/mapcli/map/mod.rs
@@ -8,11 +8,8 @@ mod vbtree;
 
 pub use btree::*;
 pub use ctree::*;
-pub use pbtree::*;
 pub use rbtree::*;
 pub use rtree::*;
-pub use ubtree::*;
-pub use vbtree::*;
 
 use corundum::default::*;
 

--- a/examples/mapcli/map/rtree.rs
+++ b/examples/mapcli/map/rtree.rs
@@ -1,20 +1,12 @@
-#![allow(invalid_reference_casting)]
-
 use crate::map::Map;
 use corundum::default::*;
 
-use std::collections::BTreeMap;
+use std::{cell::UnsafeCell, collections::BTreeMap};
 
 type P = Allocator;
 
 pub struct RTree<K, V> {
-    btree: BTreeMap<K, V>,
-}
-
-impl<K, V> RTree<K, V> {
-    fn self_mut(&self) -> &mut Self {
-        unsafe { &mut *(self as *const Self as *mut Self) }
-    }
+    btree: UnsafeCell<BTreeMap<K, V>>,
 }
 
 impl<K, V: Copy> Map<K, V> for RTree<K, V>
@@ -22,32 +14,34 @@ where
     K: std::cmp::Ord,
 {
     fn clear(&self) {
-        self.self_mut().btree.clear();
+        unsafe { (*self.btree.get()).clear(); }
     }
     fn insert(&self, key: K, val: V) {
-        self.self_mut().btree.insert(key, val);
+        unsafe { (*self.btree.get()).insert(key, val); }
     }
     fn remove(&self, key: K) {
-        self.self_mut().btree.remove(&key);
+        unsafe { (*self.btree.get()).remove(&key); }
     }
     fn is_empty(&self) -> bool {
-        self.btree.is_empty()
+        unsafe { (*self.btree.get()).is_empty() }
     }
     fn foreach<F: Copy + Fn(&K, &V) -> bool>(&self, f: F) -> bool {
-        for (k, v) in &self.btree {
-            f(k, v);
+        unsafe {
+                for (k, v) in &*self.btree.get() {
+                f(k, v);
+            }
+            true
         }
-        true
     }
     fn lookup(&self, key: K) -> bool {
-        self.btree.get(&key).is_some()
+        unsafe { (*self.btree.get()).get(&key).is_some() }
     }
 }
 
 impl<K: std::cmp::Ord, V> Default for RTree<K, V> {
     fn default() -> Self {
         Self {
-            btree: BTreeMap::new(),
+            btree: UnsafeCell::new(BTreeMap::new()),
         }
     }
 }

--- a/examples/mapcli/map/rtree.rs
+++ b/examples/mapcli/map/rtree.rs
@@ -9,32 +9,36 @@ pub struct RTree<K, V> {
     btree: UnsafeCell<BTreeMap<K, V>>,
 }
 
+impl<K, V> RTree<K, V> {
+    fn get(&self) -> &mut BTreeMap<K, V> {
+        unsafe { &mut *self.btree.get() }
+    }
+}
+
 impl<K, V: Copy> Map<K, V> for RTree<K, V>
 where
     K: std::cmp::Ord,
 {
     fn clear(&self) {
-        unsafe { (*self.btree.get()).clear(); }
+        self.get().clear();
     }
     fn insert(&self, key: K, val: V) {
-        unsafe { (*self.btree.get()).insert(key, val); }
+        self.get().insert(key, val);
     }
     fn remove(&self, key: K) {
-        unsafe { (*self.btree.get()).remove(&key); }
+        self.get().remove(&key);
     }
     fn is_empty(&self) -> bool {
-        unsafe { (*self.btree.get()).is_empty() }
+        self.get().is_empty()
     }
     fn foreach<F: Copy + Fn(&K, &V) -> bool>(&self, f: F) -> bool {
-        unsafe {
-                for (k, v) in &*self.btree.get() {
-                f(k, v);
-            }
-            true
+        for (k, v) in self.get() {
+            f(k, v);
         }
+        true
     }
     fn lookup(&self, key: K) -> bool {
-        unsafe { (*self.btree.get()).get(&key).is_some() }
+        self.get().get(&key).is_some()
     }
 }
 

--- a/examples/mapcli/map/rtree.rs
+++ b/examples/mapcli/map/rtree.rs
@@ -1,3 +1,5 @@
+#![allow(invalid_reference_casting)]
+
 use crate::map::Map;
 use corundum::default::*;
 

--- a/examples/microbench.rs
+++ b/examples/microbench.rs
@@ -283,7 +283,7 @@ mod run {
             let layout = std::alloc::Layout::from_size_align(*s * 8, 4).unwrap();
             measure!(format!("malloc({})", *s * 8), cnt, {
                 for _ in 0..cnt {
-                    unsafe{ std::alloc::alloc(layout); }
+                    unsafe{ let _ = std::alloc::alloc(layout); }
                 }
             });
         }

--- a/examples/microbench.rs
+++ b/examples/microbench.rs
@@ -6,6 +6,7 @@ mod run {
     use corundum::stat::*;
     use corundum::open_flags::*;
     use corundum::stm::{Log, Logger, Notifier};
+    use std::arch::asm;
     
     type P = Allocator;
     const CNT: usize = 50000;
@@ -28,7 +29,7 @@ mod run {
         };
     }
     
-    fn main() {
+    pub fn main() {
         use std::env;
         use std::vec::Vec as StdVec;
     

--- a/examples/simplekv.rs
+++ b/examples/simplekv.rs
@@ -6,7 +6,6 @@
 
 #![allow(dead_code)]
 #![allow(incomplete_features)]
-#![feature(type_name_of_val)]
 
 use std::mem::MaybeUninit;
 use corundum::default::*;

--- a/src/alloc/alg/buddy.rs
+++ b/src/alloc/alg/buddy.rs
@@ -232,7 +232,7 @@ impl<A: MemPool> BuddyAlg<A> {
         self.aux.clear();
         self.log64.foreach(|(off, data)| unsafe {
             let n = Self::buddy(off);
-            std::intrinsics::atomic_store_rel(&mut n.next, data);
+            std::intrinsics::atomic_store_release(&mut n.next, data);
         });
         self.log64.clear();
         self.available = self.available_log;

--- a/src/alloc/alg/buddy.rs
+++ b/src/alloc/alg/buddy.rs
@@ -176,7 +176,7 @@ impl<A: MemPool> BuddyAlg<A> {
 
             #[cfg(any(feature = "no_pthread", windows))] {
                 let tid = std::thread::current().id().as_u64().get();
-                while std::intrinsics::atomic_cxchg_acqrel(&mut self.mutex, 0, tid).0 != tid {}
+                while std::intrinsics::atomic_cxchg_acqrel_acquire(&mut self.mutex, 0, tid).0 != tid {}
             }
         }
     }
@@ -188,7 +188,7 @@ impl<A: MemPool> BuddyAlg<A> {
             libc::pthread_mutex_unlock(&mut self.mutex.0); 
 
             #[cfg(any(feature = "no_pthread", windows))]
-            std::intrinsics::atomic_store_rel(&mut self.mutex, 0);
+            std::intrinsics::atomic_store_release(&mut self.mutex, 0);
         }
     }
 

--- a/src/alloc/alg/buddy.rs
+++ b/src/alloc/alg/buddy.rs
@@ -5,6 +5,7 @@ use std::ops::{Index,IndexMut};
 use std::marker::PhantomData;
 use std::mem;
 
+
 #[repr(transparent)]
 #[derive(Clone, Debug)]
 /// Buddy memory block
@@ -1003,6 +1004,7 @@ macro_rules! pool {
     ($mod:ident, $name:ident) => {
         /// The default allocator module
         pub mod $mod {
+            #![allow(unused_imports)]
             use memmap::*;
             use std::collections::hash_map::DefaultHasher;
             use std::collections::{HashMap,HashSet};

--- a/src/alloc/heap.rs
+++ b/src/alloc/heap.rs
@@ -149,7 +149,7 @@ unsafe impl MemPoolTraits for Heap {
 
     unsafe fn journals_head() -> &'static u64 {
         static mut HEAD: u64 = u64::MAX;
-        &HEAD
+        &*std::ptr::addr_of!(HEAD)
     }
 
     unsafe fn close() -> Result<()> {

--- a/src/cell/cell.rs
+++ b/src/cell/cell.rs
@@ -272,11 +272,6 @@ impl<T: PSafe, A: MemPool> PCell<T, A> {
             self.value.into_inner().1
         }
     }
-
-    #[inline]
-    fn self_mut(&self) -> &mut Self {
-        unsafe { &mut *(self as *const Self as *mut Self) }
-    }
 }
 
 impl<T: PSafe, A: MemPool> PCell<T, A> {

--- a/src/cell/refcell.rs
+++ b/src/cell/refcell.rs
@@ -208,15 +208,6 @@ impl<T: PSafe + Debug + ?Sized, A: MemPool> Debug for PRefCell<T, A> {
 }
 
 impl<T: PSafe + ?Sized, A: MemPool> PRefCell<T, A> {
-    #[inline(always)]
-    #[allow(clippy::mut_from_ref)]
-    fn self_mut(&self) -> &mut Self {
-        unsafe {
-            let ptr: *const Self = self;
-            &mut *(ptr as *mut Self)
-        }
-    }
-
     #[inline]
     #[allow(clippy::mut_from_ref)]
     /// Takes a log and returns a mutable reference to the underlying data.
@@ -476,7 +467,7 @@ impl<T: PSafe, A: MemPool> PRefCell<T, A> {
             *borrow = 1;
         }
         RefMut {
-            value: unsafe { &mut *(self as *const Self as *mut Self) },
+            value: self as *const Self as *mut Self,
             journal,
             phantom: PhantomData
         }

--- a/src/cell/tcell.rs
+++ b/src/cell/tcell.rs
@@ -78,6 +78,11 @@ impl<T: Default + VSafe, A: MemPool> TCell<T, A> {
     }
 
     #[inline]
+    pub(crate) fn as_mut(&self) -> &mut T {
+        unsafe { utils::as_mut(self).force() }
+    }
+
+    #[inline]
     /// Create a new invalid cell to be used in const functions
     pub const fn new_invalid(v: T) -> Self {
         Self {

--- a/src/cell/tcell.rs
+++ b/src/cell/tcell.rs
@@ -78,11 +78,6 @@ impl<T: Default + VSafe, A: MemPool> TCell<T, A> {
     }
 
     #[inline]
-    pub(crate) fn as_mut(&self) -> &mut T {
-        unsafe { &mut *(self.deref() as *const T as *mut T) }
-    }
-
-    #[inline]
     /// Create a new invalid cell to be used in const functions
     pub const fn new_invalid(v: T) -> Self {
         Self {

--- a/src/cell/vcell.rs
+++ b/src/cell/vcell.rs
@@ -60,7 +60,7 @@ impl<T: Default + VSafe, A: MemPool> VCell<T, A> {
 
     #[inline]
     pub(crate) fn as_mut(&self) -> &mut T {
-        unsafe {&mut *self.value.get()}
+        unsafe { &mut *self.value.get() }
     }
 
     #[inline]
@@ -126,7 +126,7 @@ impl<T: Default + VSafe, A: MemPool> DerefMut for VCell<T, A> {
 impl<T: Default + VSafe + PartialEq + Copy, A: MemPool> PartialEq for VCell<T, A> {
     #[inline]
     fn eq(&self, other: &VCell<T, A>) -> bool {
-        unsafe {*self.value.get() == *other.value.get()}
+        unsafe { *self.value.get() == *other.value.get() }
     }
 }
 
@@ -135,67 +135,67 @@ impl<T: Default + VSafe + Eq + Copy, A: MemPool> Eq for VCell<T, A> {}
 impl<T: Default + VSafe + PartialOrd + Copy, A: MemPool> PartialOrd for VCell<T, A> {
     #[inline]
     fn partial_cmp(&self, other: &VCell<T, A>) -> Option<Ordering> {
-        unsafe {(*self.value.get()).partial_cmp(&*other.value.get())}
+        unsafe { (*self.value.get()).partial_cmp(&*other.value.get()) }
     }
 
     #[inline]
     fn lt(&self, other: &VCell<T, A>) -> bool {
-        unsafe {*self.value.get() < *other.value.get()}
+        unsafe { *self.value.get() < *other.value.get() }
     }
 
     #[inline]
     fn le(&self, other: &VCell<T, A>) -> bool {
-        unsafe {*self.value.get() <= *other.value.get()}
+        unsafe { *self.value.get() <= *other.value.get() }
     }
 
     #[inline]
     fn gt(&self, other: &VCell<T, A>) -> bool {
-        unsafe {*self.value.get() > *other.value.get()}
+        unsafe { *self.value.get() > *other.value.get() }
     }
 
     #[inline]
     fn ge(&self, other: &VCell<T, A>) -> bool {
-        unsafe {*self.value.get() >= *other.value.get()}
+        unsafe { *self.value.get() >= *other.value.get() }
     }
 }
 
 impl<T: Default + VSafe + Ord + Copy, A: MemPool> Ord for VCell<T, A> {
     #[inline]
     fn cmp(&self, other: &VCell<T, A>) -> Ordering {
-        unsafe {(*self.value.get()).cmp(&*other.value.get())}
+        unsafe { (*self.value.get()).cmp(&*other.value.get()) }
     }
 }
 
 impl<T: Default + VSafe + PartialEq + Copy, A: MemPool> PartialEq<T> for VCell<T, A> {
     #[inline]
     fn eq(&self, other: &T) -> bool {
-        unsafe {*self.value.get() == *other}
+        unsafe { *self.value.get() == *other }
     }
 }
 
 impl<T: Default + VSafe + PartialOrd + Copy, A: MemPool> PartialOrd<T> for VCell<T, A> {
     #[inline]
     fn partial_cmp(&self, other: &T) -> Option<Ordering> {
-        unsafe {(*self.value.get()).partial_cmp(&other)}
+        unsafe { (*self.value.get()).partial_cmp(&other) }
     }
 
     #[inline]
     fn lt(&self, other: &T) -> bool {
-        unsafe {*self.value.get() < *other}
+        unsafe { *self.value.get() < *other }
     }
 
     #[inline]
     fn le(&self, other: &T) -> bool {
-        unsafe {*self.value.get() <= *other}
+        unsafe { *self.value.get() <= *other }
     }
 
     #[inline]
     fn gt(&self, other: &T) -> bool {
-        unsafe {*self.value.get() > *other}
+        unsafe { *self.value.get() > *other }
     }
 
     #[inline]
     fn ge(&self, other: &T) -> bool {
-        unsafe {*self.value.get() >= *other}
+        unsafe { *self.value.get() >= *other }
     }
 }

--- a/src/cell/vcell.rs
+++ b/src/cell/vcell.rs
@@ -58,6 +58,10 @@ impl<T: Default + VSafe, A: MemPool> VCell<T, A> {
         }
     }
 
+    fn get_value(&self) -> &mut T {
+        unsafe { &mut *self.value.get() }
+    }
+
     #[inline]
     pub(crate) fn as_mut(&self) -> &mut T {
         unsafe { utils::as_mut(self).force() }
@@ -126,7 +130,7 @@ impl<T: Default + VSafe, A: MemPool> DerefMut for VCell<T, A> {
 impl<T: Default + VSafe + PartialEq + Copy, A: MemPool> PartialEq for VCell<T, A> {
     #[inline]
     fn eq(&self, other: &VCell<T, A>) -> bool {
-        unsafe { *self.value.get() == *other.value.get() }
+        self.get_value() == other.get_value()
     }
 }
 
@@ -135,67 +139,67 @@ impl<T: Default + VSafe + Eq + Copy, A: MemPool> Eq for VCell<T, A> {}
 impl<T: Default + VSafe + PartialOrd + Copy, A: MemPool> PartialOrd for VCell<T, A> {
     #[inline]
     fn partial_cmp(&self, other: &VCell<T, A>) -> Option<Ordering> {
-        unsafe { (*self.value.get()).partial_cmp(&*other.value.get()) }
+        self.get_value().partial_cmp(&other.get_value())
     }
 
     #[inline]
     fn lt(&self, other: &VCell<T, A>) -> bool {
-        unsafe { *self.value.get() < *other.value.get() }
+        self.get_value() < other.get_value()
     }
 
     #[inline]
     fn le(&self, other: &VCell<T, A>) -> bool {
-        unsafe { *self.value.get() <= *other.value.get() }
+        self.get_value() <= other.get_value()
     }
 
     #[inline]
     fn gt(&self, other: &VCell<T, A>) -> bool {
-        unsafe { *self.value.get() > *other.value.get() }
+        self.get_value() > other.get_value()
     }
 
     #[inline]
     fn ge(&self, other: &VCell<T, A>) -> bool {
-        unsafe { *self.value.get() >= *other.value.get() }
+        self.get_value() >= other.get_value()
     }
 }
 
 impl<T: Default + VSafe + Ord + Copy, A: MemPool> Ord for VCell<T, A> {
     #[inline]
     fn cmp(&self, other: &VCell<T, A>) -> Ordering {
-        unsafe { (*self.value.get()).cmp(&*other.value.get()) }
+        self.get_value().cmp(&other.get_value())
     }
 }
 
 impl<T: Default + VSafe + PartialEq + Copy, A: MemPool> PartialEq<T> for VCell<T, A> {
     #[inline]
     fn eq(&self, other: &T) -> bool {
-        unsafe { *self.value.get() == *other }
+        *self.get_value() == *other
     }
 }
 
 impl<T: Default + VSafe + PartialOrd + Copy, A: MemPool> PartialOrd<T> for VCell<T, A> {
     #[inline]
     fn partial_cmp(&self, other: &T) -> Option<Ordering> {
-        unsafe { (*self.value.get()).partial_cmp(&other) }
+        (*self.get_value()).partial_cmp(&other)
     }
 
     #[inline]
     fn lt(&self, other: &T) -> bool {
-        unsafe { *self.value.get() < *other }
+        *self.get_value() < *other
     }
 
     #[inline]
     fn le(&self, other: &T) -> bool {
-        unsafe { *self.value.get() <= *other }
+        *self.get_value() <= *other
     }
 
     #[inline]
     fn gt(&self, other: &T) -> bool {
-        unsafe { *self.value.get() > *other }
+        *self.get_value() > *other
     }
 
     #[inline]
     fn ge(&self, other: &T) -> bool {
-        unsafe { *self.value.get() >= *other }
+        *self.get_value() >= *other
     }
 }

--- a/src/cell/vcell.rs
+++ b/src/cell/vcell.rs
@@ -60,7 +60,7 @@ impl<T: Default + VSafe, A: MemPool> VCell<T, A> {
 
     #[inline]
     pub(crate) fn as_mut(&self) -> &mut T {
-        unsafe { &mut *self.value.get() }
+        unsafe { utils::as_mut(self).force() }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,13 +102,11 @@
 //! [`open<T>()`]: ./alloc/struct.MemPool.html#method.open
 
 #![feature(auto_traits)]
-#![feature(untagged_unions)]
 #![feature(specialization)]
 #![feature(concat_idents)]
 #![feature(core_intrinsics)]
 #![feature(thread_id_value)]
 #![feature(negative_impls)]
-#![feature(backtrace)]
 #![feature(trusted_len)]
 #![feature(exact_size_is_empty)]
 #![feature(alloc_layout_extra)]
@@ -118,22 +116,20 @@
 #![feature(trait_alias)]
 #![feature(slice_concat_trait)]
 #![feature(slice_partition_dedup)]
-#![feature(type_name_of_val)]
 #![feature(pattern)]
 #![feature(str_internals)]
-#![feature(toowned_clone_into)]
 #![feature(fn_traits)]
 #![feature(unboxed_closures)]
 #![feature(let_chains)]
 #![feature(c_variadic)]
 #![feature(rustc_attrs)]
 #![feature(allocator_api)]
-#![feature(associated_type_bounds)]
 // #![feature(async_stream)]
 
 #![allow(dead_code)]
 #![allow(incomplete_features)]
 #![allow(type_alias_bounds)]
+#![allow(invalid_reference_casting)]
 
 pub(crate) const PAGE_LOG_SLOTS: usize = 128;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@
 #![allow(incomplete_features)]
 #![allow(type_alias_bounds)]
 #![allow(internal_features)]
+#![allow(unexpected_cfgs)]
 
 pub(crate) const PAGE_LOG_SLOTS: usize = 128;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@
 #![allow(dead_code)]
 #![allow(incomplete_features)]
 #![allow(type_alias_bounds)]
+#![allow(internal_features)]
 
 pub(crate) const PAGE_LOG_SLOTS: usize = 128;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,6 @@
 #![allow(dead_code)]
 #![allow(incomplete_features)]
 #![allow(type_alias_bounds)]
-#![allow(invalid_reference_casting)]
 
 pub(crate) const PAGE_LOG_SLOTS: usize = 128;
 

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -133,6 +133,6 @@ pub fn sfence() {
 #[inline]
 pub fn mfence() {
     unsafe {
-        std::intrinsics::atomic_fence()
+        std::intrinsics::atomic_fence_seqcst()
     }
 }

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -45,7 +45,7 @@ pub fn persist<T: ?Sized>(ptr: *const T, len: usize, fence: bool) {
             let off = (off >> 12) << 12;
             let len = end - off;
             let ptr = off as *const u8;
-            if libc::persist(
+            if libc::msync(
                 ptr as *mut libc::c_void,
                 len,
                 libc::MS_SYNC | libc::MS_INVALIDATE,

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -126,7 +126,7 @@ pub unsafe auto trait TxInSafe {}
 pub unsafe auto trait LooseTxInUnsafe {}
 
 /// Any type is okay to be transferred to a transaction
-unsafe impl LooseTxInUnsafe for dyn std::any::Any {}
+//unsafe impl LooseTxInUnsafe for dyn std::any::Any {}
 unsafe impl<'a, T> LooseTxInUnsafe for &'a mut T {}
 unsafe impl<T> LooseTxInUnsafe for *const T {}
 unsafe impl<T> LooseTxInUnsafe for *mut T {}

--- a/src/ptr/non_null.rs
+++ b/src/ptr/non_null.rs
@@ -37,7 +37,7 @@ impl<T: ?Sized> !Sync for NonNull<T> {}
 impl<T: PSafe + ?Sized> PartialEq for NonNull<T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.ptr == other.ptr
+        std::ptr::addr_eq(self.ptr, other.ptr)
     }
 }
 
@@ -170,7 +170,7 @@ impl<T: ?Sized, A: MemPool> !Sync for LogNonNull<T, A> {}
 impl<T: PSafe + ?Sized, A: MemPool> PartialEq for LogNonNull<T, A> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.ptr == other.ptr
+        std::ptr::addr_eq(self.ptr, other.ptr)
     }
 }
 

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -93,7 +93,7 @@ static mut STAT: LazyCell<Mutex<HashMap<(ThreadId, &'static str), Stat>>> =
 #[inline]
 fn hist_enabled() -> bool {
     unsafe {
-        if let Some(hist) = &mut HIST {
+        if let Some(hist) = &mut *std::ptr::addr_of_mut!(HIST) {
             *hist
         } else {
             if let Some(val) = std::env::var_os("HIST") {
@@ -110,7 +110,7 @@ fn hist_enabled() -> bool {
 #[inline]
 fn points_enabled() -> bool {
     unsafe {
-        if let Some(points) = &mut POINTS {
+        if let Some(points) = &mut *std::ptr::addr_of_mut!(POINTS) {
             *points
         } else {
             if let Some(val) = std::env::var_os("POINTS") {

--- a/src/stm/log.rs
+++ b/src/stm/log.rs
@@ -85,8 +85,6 @@ pub enum Notifier<A: MemPool> {
     None,
 }
 
-impl<A: MemPool> Copy for Notifier<A> {}
-
 impl<A: MemPool> Clone for Notifier<A> {
     fn clone(&self) -> Self {
         use Notifier::*;
@@ -154,11 +152,9 @@ impl<A: MemPool> Notifier<A> {
 /// 
 pub struct Log<A: MemPool>(LogEnum, Notifier<A>);
 
-impl<A: MemPool> Copy for Log<A> {}
-
 impl<A: MemPool> Clone for Log<A> {
     fn clone(&self) -> Self {
-        Self(self.0, self.1)
+        Self(self.0, self.1.clone())
     }
 }
 

--- a/src/stm/log.rs
+++ b/src/stm/log.rs
@@ -107,7 +107,7 @@ impl<A: MemPool> Notifier<A> {
         match self {
             Atomic(n) => {
                 if let Some(n) = n.as_option() {
-                    unsafe { std::intrinsics::atomic_store_rel(n.as_mut_ptr(), v) }
+                    unsafe { std::intrinsics::atomic_store_release(n.as_mut_ptr(), v) }
                 }
             }
             NonAtomic(n) => {

--- a/src/stm/pspd.rs
+++ b/src/stm/pspd.rs
@@ -43,7 +43,7 @@ impl<A: MemPool> Page<A> {
                 let pg = utils::read::<Page<A>>(p);
                 pg.cap = cap - mem::size_of::<Page<A>>();
                 pg.len = 0;
-                pg.next = self.next;
+                pg.next = self.next.clone();
                 A::log64(A::off_unchecked(self.next.off_mut()), off, z);
                 A::perform(z);
                 pg.write(val, org_off)

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -262,7 +262,7 @@ impl<T, A: MemPool> PMutex<T, A> {
             #[cfg(any(feature = "no_pthread", windows))]
             let result = {
                 let tid = std::thread::current().id().as_u64().get();
-                intrinsics::atomic_cxchg_acqrel(lock, 0, tid).0 == tid
+                intrinsics::atomic_cxchg_acqrel_acquire(lock, 0, tid).0 == tid
             };
 
             if result {
@@ -274,7 +274,7 @@ impl<T, A: MemPool> PMutex<T, A> {
                     libc::pthread_mutex_unlock(lock);
 
                     #[cfg(any(feature = "no_pthread", windows))] 
-                    intrinsics::atomic_store_rel(lock, 0);
+                    intrinsics::atomic_store_release(lock, 0);
 
                     panic!("Cannot have multiple instances of MutexGuard");
                 }

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -178,15 +178,6 @@ impl<T: PSafe, A: MemPool> PMutex<T, A> {
             &mut inner.1
         }
     }
-
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn self_mut(&self) -> &mut Self {
-        unsafe {
-            let ptr: *const Self = self;
-            &mut *(ptr as *mut Self)
-        }
-    }
 }
 
 impl<T, A: MemPool> PMutex<T, A> {

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -191,7 +191,7 @@ impl<T, A: MemPool> PMutex<T, A> {
             }
             #[cfg(any(feature = "no_pthread", windows))] {
                 let tid = std::thread::current().id().as_u64().get();
-                while intrinsics::atomic_cxchg_acqrel(lock, 0, tid).0 != tid {}
+                while intrinsics::atomic_cxchg_acqrel_acquire(lock, 0, tid).0 != tid {}
             }
             if self.inner.acquire() {
                 Log::unlock_on_commit(&self.inner.lock as *const _ as u64, journal);
@@ -200,7 +200,7 @@ impl<T, A: MemPool> PMutex<T, A> {
                 libc::pthread_mutex_unlock(lock);
 
                 #[cfg(any(feature = "no_pthread", windows))] 
-                intrinsics::atomic_store_rel(lock, 0);
+                intrinsics::atomic_store_release(lock, 0);
 
                 panic!("Cannot have multiple instances of MutexGuard");
             }

--- a/src/sync/parc.rs
+++ b/src/sync/parc.rs
@@ -740,7 +740,7 @@ impl<T: PSafe + ?Sized, A: MemPool> PClone<A> for Parc<T, A> {
             std::process::abort();
         }
 
-        Self::from_inner(self.ptr)
+        Self::from_inner(self.ptr.clone())
     }
 }
 
@@ -964,7 +964,7 @@ impl<T: PSafe + ?Sized, A: MemPool> Weak<T, A> {
         }
 
         lock_free_fetch_inc(&mut inner.counter.strong, j);
-        Some(Parc::from_inner(self.ptr))
+        Some(Parc::from_inner(self.ptr.clone()))
     }
 
     /// Gets the number of strong (`Parc`) pointers pointing to this allocation.
@@ -1068,7 +1068,7 @@ impl<T: PSafe + ?Sized, A: MemPool> PClone<A> for Weak<T, A> {
         let inner = if let Some(inner) = self.inner() {
             inner
         } else {
-            return Weak { ptr: self.ptr };
+            return Weak { ptr: self.ptr.clone() };
         };
 
         // See comments in Arc::clone() for why this is relaxed.  This can use a
@@ -1083,7 +1083,7 @@ impl<T: PSafe + ?Sized, A: MemPool> PClone<A> for Weak<T, A> {
             std::process::abort();
         }
 
-        Weak { ptr: self.ptr }
+        Weak { ptr: self.ptr.clone() }
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1159,7 +1159,7 @@ pub(crate) mod test {
             if IDX == 16 {
                 IDX = 0;
                 let mut f = File::open("/dev/urandom").unwrap();
-                f.read_exact(&mut BUF).unwrap();
+                f.read_exact(&mut *std::ptr::addr_of_mut!(BUF)).unwrap();
             }
             BUF[IDX]
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1383,13 +1383,8 @@ pub(crate) mod test {
 
         impl<'a> std::ops::AddAssign<&'a str> for MyString<'a> {
             fn add_assign(&mut self, other: &'a str) {
-                unsafe {
-                    let m: *const [u8] = self.value;
-                    let m: *mut [u8] = m as *mut [u8];
-                    let m: &mut [u8] = &mut *m;
-                    let mut v = m.to_vec();
-                    v.append(&mut other.as_bytes().to_vec());
-                }
+                let mut v = self.value.to_vec();
+                v.append(&mut other.as_bytes().to_vec());
             }
         }
         impl<'a> From<&'a str> for MyString<'a> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -280,7 +280,7 @@ pub struct SpinLock {
 
 impl SpinLock {
     pub fn acquire(lock: *mut u8) -> Self {
-        unsafe { while std::intrinsics::atomic_cxchg_acquire_relaxed(lock, 0, 1).0 == 1 {} }
+        unsafe { while std::intrinsics::atomic_cxchg_acqrel_acquire(lock, 0, 1).0 == 1 {} }
         Self { lock }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -280,14 +280,14 @@ pub struct SpinLock {
 
 impl SpinLock {
     pub fn acquire(lock: *mut u8) -> Self {
-        unsafe { while std::intrinsics::atomic_cxchg_acqrel(lock, 0, 1).0 == 1 {} }
+        unsafe { while std::intrinsics::atomic_cxchg_acquire_relaxed(lock, 0, 1).0 == 1 {} }
         Self { lock }
     }
 }
 
 impl Drop for SpinLock {
     fn drop(&mut self) {
-        unsafe { std::intrinsics::atomic_store_rel(self.lock, 0); }
+        unsafe { std::intrinsics::atomic_store_release(self.lock, 0); }
     }
 }
 


### PR DESCRIPTION
Hello Corundum team, I tried to make it compatible with current latest nightly: rustc 1.80.0-nightly (b1ec1bd65 2024-05-18)

The changes are mainly:

- Point `crndm_derive` to the one in the repo (seems like it's more updated than the published one? And with the published one Corundum won't compile)
- `SyncLazy` becomes `LazyLock`
- Use `UnsafeCell` as now getting `&mut` from `&` is UB (not sure if it's the idiomatic approach though)
- Comment out the line that implements `LooseTxInUnsafe` for `dyn Any` as now implementing auto trait for trait objects is not allowed (not sure the impact of removing the line)
- Some atomic functions are renamed
- Fix warnings generated by latest nightly, remove stabilized features

Please let me know if there are any issues, thanks!